### PR TITLE
Clean up edit

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,8 +28,8 @@
             <li class="nav-item">
                 <a class="nav-link" href="/logout">Logout</a>
             </li>
-            <li class="nav-item">
-                <a class="nav-link" href="/edit">Change Default Location</a>
+            <li class="nav-edit" >
+                <a class="nav-link" href="/edit" id='edit'>Change Default Location</a>
             </li>
           <% end %>
         </ul>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -22,6 +22,4 @@
   <%= submit_tag "weather-bop somewhere else!" %>
 <% end %>
 
-<%= button_to 'change your default location', user_edit_path, method: :get %>
-
 <iframe  src=<%="https://open.spotify.com/embed/playlist/#{@weather_music.playlist_id}"%> width="500" height="580" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,6 @@ Rails.application.routes.draw do
   get '/logout', to: 'sessions#destroy', as: 'logout'
   get '/auth/failure', to: 'welcome#failure', as: 'login_fail'
   get '/dashboard', to: 'users#show', as: 'dashboard'
-  get '/users/edit', to: 'users#edit', as: 'user_edit'
+  get '/edit', to: 'users#edit', as: 'user_edit'
   patch '/users', to: 'users#update'
 end

--- a/spec/features/users/edit_default_location_spec.rb
+++ b/spec/features/users/edit_default_location_spec.rb
@@ -50,8 +50,8 @@ RSpec.describe "As a logged in user" do
 
         expect(current_path).to eq('/dashboard')
         expect(josh.default_location).to eq('denver')
-
-        click_button('change your default location')
+        
+        click_on('edit')
 
         expect(current_path).to eq(user_edit_path)
         expect(page).to have_content('City')
@@ -74,12 +74,12 @@ RSpec.describe "As a logged in user" do
         click_link('login')
         weather_music = WeatherMusic.new(@weather_music_data, josh.default_location)
 
-        click_button('change your default location')
+        click_on('edit')
         expect(current_path).to eq(user_edit_path)
         fill_in :city, with: "Boston"
         select('Massachusetts', :from => :state)
         select('United States', :from => :country)
-        click_on 'change your default location'
+        click_on('change your default location')
         expect(current_path).to eq(dashboard_path)
 
         expect(page).to have_content("it's a great day to be in boston")
@@ -98,11 +98,11 @@ RSpec.describe "As a logged in user" do
         click_link('login')
         weather_music = WeatherMusic.new(@weather_music_data, josh.default_location)
 
-        click_button('change your default location')
+        click_on('edit')
         fill_in :city, with: "Boston"
         select('Massachusetts', :from => :state)
         select('United States', :from => :country)
-        click_on 'change your default location'
+        click_on('change your default location')
         expect(current_path).to eq(dashboard_path)
         expect(page).to have_content("it's a great day to be in boston")
     end


### PR DESCRIPTION
This branch pulls the 'edit default location' button out of the body of the show page and moves it up to the nav bar with testing